### PR TITLE
Fix code error for UE5 build

### DIFF
--- a/Source/ReplicatedALS/Private/Components/ALSCharacterMovementComponent.cpp
+++ b/Source/ReplicatedALS/Private/Components/ALSCharacterMovementComponent.cpp
@@ -112,15 +112,20 @@ float UALSCharacterMovementComponent::GetMappedSpeed() const
 
 	if (Speed > LocRunSpeed)
 	{
-		return FMath::GetMappedRangeValueClamped({LocRunSpeed, LocSprintSpeed}, {2.0f, 3.0f}, Speed);
+		const TRange<float>* InputRange = new TRange<float>(LocRunSpeed, LocSprintSpeed);
+		const TRange<float>* OutputRange = new TRange<float>(2.0f, 3.0f);
+		return FMath::GetMappedRangeValueClamped(*InputRange, *OutputRange, Speed);
 	}
 
 	if (Speed > LocWalkSpeed)
 	{
-		return FMath::GetMappedRangeValueClamped({LocWalkSpeed, LocRunSpeed}, {1.0f, 2.0f}, Speed);
+		const TRange<float>* InputRange = new TRange<float>(LocWalkSpeed, LocRunSpeed);
+		const TRange<float>* OutputRange = new TRange<float>(1.0f, 2.0f);
+		return FMath::GetMappedRangeValueClamped(*InputRange, *OutputRange, Speed);
 	}
-
-	return FMath::GetMappedRangeValueClamped({0.0f, LocWalkSpeed}, {0.0f, 1.0f}, Speed);
+	const TRange<float>* InputRange = new TRange<float>(0.0f, LocWalkSpeed);
+	const TRange<float>* OutputRange = new TRange<float>(0.0f, 1.0f);
+	return FMath::GetMappedRangeValueClamped(*InputRange, *OutputRange, Speed);
 }
 
 void UALSCharacterMovementComponent::SetMovementSettings(FALSMovementSettings NewMovementSettings)


### PR DESCRIPTION
I was trying to use the plugin on a brand new project based on UE 5.0.2. 
I came across some compiling errors when VS tried to rebuild the plugin. 
This is a quick solution.
I tested with a new project and everything works.
Hope it helps!

I post the error I received : 
Errore C2664 'TRange<float>::TRange(const float,const float)': cannot convert argument 1 from 'initializer list' to 'const float'	
